### PR TITLE
Add Python-based EXE build script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
-# MBOX-To-PST-CSV
-MBOX-To-PST/CSV
+# MBOX Converter
+
+This project provides a simple command-line tool for converting Mozilla
+`mbox` files to either CSV or Outlook PST format.
+
+The converter is fully open source and distributed under the MIT license.
+There are no limitations or subscriptions required.
+
+## Requirements
+
+* Python 3.8+
+* For PST conversion you must run on Windows with Microsoft Outlook installed
+  and have the `pywin32` package available.
+
+## Installation
+
+Create a virtual environment (optional) and install the required Python
+packages:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+pip install -r requirements.txt
+```
+
+## Usage
+
+Convert an MBOX file to CSV:
+
+```bash
+python mbox_converter.py input.mbox --csv output.csv
+```
+
+Convert an MBOX file to a PST (Windows + Outlook only):
+
+```bash
+python mbox_converter.py input.mbox --pst output.pst
+```
+
+## Building on Windows
+
+The PST conversion relies on Outlook COM automation. Ensure Outlook is installed
+and Python has access to the `pywin32` package. The script creates a new PST
+file and imports all messages from the MBOX file.
+
+
+### Building a Windows executable
+
+To create a standalone `mbox_converter.exe` run the helper script
+`build_exe.py`:
+
+```bash
+python build_exe.py
+```
+
+The script installs PyInstaller if necessary and produces
+`dist\mbox_converter.exe`, which runs without requiring Python or
+PowerShell on the target machine.
+
+### Using the convenience batch script
+
+Windows users can run `run_converter.bat` directly. The script uses the
+built-in `curl` command to install Python if needed and then invokes
+`mbox_converter.py` with any arguments you supply:
+
+```cmd
+run_converter.bat input.mbox --csv output.csv
+```
+

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,20 @@
+"""Cross-platform script to build a standalone Windows EXE using PyInstaller."""
+import subprocess
+import sys
+
+
+def ensure_pyinstaller() -> None:
+    """Ensure PyInstaller is installed."""
+    try:
+        import PyInstaller  # type: ignore
+    except ImportError:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "pyinstaller"])  # noqa: E501
+
+
+def build():
+    ensure_pyinstaller()
+    subprocess.check_call([sys.executable, "-m", "PyInstaller", "--onefile", "mbox_converter.py"])
+
+
+if __name__ == "__main__":
+    build()

--- a/mbox_converter.py
+++ b/mbox_converter.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Simple MBOX to CSV/PST converter."""
+
+import argparse
+import csv
+import mailbox
+import os
+import sys
+
+
+def get_body(message):
+    """Extract plain text body from an email message."""
+    if message.is_multipart():
+        parts = []
+        for part in message.walk():
+            if part.get_content_type() == "text/plain" and not part.get_filename():
+                data = part.get_payload(decode=True)
+                if data:
+                    charset = part.get_content_charset() or "utf-8"
+                    parts.append(data.decode(charset, errors="ignore"))
+        return "\n".join(parts)
+    payload = message.get_payload(decode=True)
+    if isinstance(payload, bytes):
+        return payload.decode(message.get_content_charset() or "utf-8", errors="ignore")
+    return payload
+
+
+def convert_to_csv(mbox_path: str, csv_path: str) -> None:
+    """Convert an MBOX file to CSV."""
+    mbox = mailbox.mbox(mbox_path)
+    with open(csv_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["From", "To", "Cc", "Bcc", "Subject", "Date", "Body"])
+        for msg in mbox:
+            writer.writerow([
+                msg.get("from", ""),
+                msg.get("to", ""),
+                msg.get("cc", ""),
+                msg.get("bcc", ""),
+                msg.get("subject", ""),
+                msg.get("date", ""),
+                get_body(msg).replace("\r", "").replace("\n", " "),
+            ])
+    mbox.close()
+
+
+def convert_to_pst(mbox_path: str, pst_path: str) -> None:
+    """Convert MBOX to PST using Outlook COM (Windows only)."""
+    try:
+        import win32com.client  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError("pywin32 is required for PST conversion") from exc
+
+    outlook = win32com.client.Dispatch("Outlook.Application").GetNamespace("MAPI")
+
+    outlook.AddStoreEx(os.path.abspath(pst_path), 3)  # 3 = olStoreUnicode
+    pst_root = None
+    for folder in outlook.Folders:
+        try:
+            if hasattr(folder, "Store") and getattr(folder.Store, "FilePath", None):
+                if os.path.abspath(folder.Store.FilePath) == os.path.abspath(pst_path):
+                    pst_root = folder
+                    break
+        except Exception:
+            continue
+
+    if pst_root is None:
+        raise RuntimeError("Failed to create PST store")
+
+    target = pst_root.Folders.Add("Imported")
+    mbox = mailbox.mbox(mbox_path)
+    for msg in mbox:
+        item = target.Items.Add()
+        item.Subject = msg.get("subject", "")
+        item.To = msg.get("to", "")
+        item.CC = msg.get("cc", "")
+        item.BCC = msg.get("bcc", "")
+        item.Sender = msg.get("from", "")
+        item.Body = get_body(msg)
+        item.Save()
+    mbox.close()
+    outlook.RemoveStore(pst_root)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert MBOX to CSV or PST")
+    parser.add_argument("mbox", help="Path to the input mbox file")
+    parser.add_argument("--csv", help="Output CSV file")
+    parser.add_argument("--pst", help="Output PST file (Windows + Outlook)")
+    args = parser.parse_args()
+
+    if not args.csv and not args.pst:
+        parser.error("Specify --csv or --pst output")
+
+    if args.csv:
+        convert_to_csv(args.mbox, args.csv)
+        print(f"CSV written to {args.csv}")
+
+    if args.pst:
+        convert_to_pst(args.mbox, args.pst)
+        print(f"PST written to {args.pst}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# required dependencies
+pywin32; platform_system == "Windows"

--- a/run_converter.bat
+++ b/run_converter.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+where python >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+    echo Python not found. Downloading installer...
+    set INST=%TEMP%\python-installer.exe
+    curl -L -o %INST% https://www.python.org/ftp/python/3.10.12/python-3.10.12-amd64.exe
+    %INST% /quiet InstallAllUsers=1 PrependPath=1
+    del %INST%
+)
+python mbox_converter.py %*


### PR DESCRIPTION
## Summary
- replace PowerShell build script with Python helper
- update README instructions
- update batch file to use `curl` instead of PowerShell

## Testing
- `python mbox_converter.py sample.mbox --csv sample.csv`
- `python build_exe.py`

------
https://chatgpt.com/codex/tasks/task_e_686ff589560883309254d0ec6cd0de21